### PR TITLE
Bugfixes in no-missing-import and no-unused-import rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,36 @@ define `foo-component`.
 </dom-module>
 ```
 
+###### Error
+
+```html
+<dom-module id="my-component">
+  <template>
+    <foo-component/>
+  </template>
+</dom-module>
+```
+
+###### Error
+
+```html
+<dom-module id="my-component">
+  <template>
+    <button is="foo-component">Submit</button>
+  </template>
+</dom-module>
+```
+
+###### Error
+
+```html
+<dom-module id="my-component">
+  <template>
+    <style include="my-styles"></style>
+  </template>
+</dom-module>
+```
+
 #### no-unused-import
 
 Ensures that all components that are imported are used.
@@ -98,6 +128,27 @@ Ensures that all components that are imported are used.
 </dom-module>
 ```
 
+###### OK
+
+```html
+<link rel="import" href="foo-component.html"/>
+<dom-module id="my-component">
+  <template>
+    <button is="foo-component">Submit</button>
+  </template>
+</dom-module>
+```
+
+###### OK
+
+```html
+<link rel="import" href="my-styles.html"/>
+<dom-module id="my-component">
+  <template>
+    <style include="my-styles"></style>
+  </template>
+</dom-module>
+```
 
 ###### Error
 

--- a/example/missing-import.html
+++ b/example/missing-import.html
@@ -1,6 +1,7 @@
 <dom-module id="missing-import">
   <template>
-    <i-am-never-imported/>
+    <style include="i-am-never-imported"></style>
+    <i-am-never-imported-either/>
   </template>
   <script>
     Polymer({ is: 'missing-import' });

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "main": "./lib/Linter.js",
   "scripts": {
-    "lint": "eslint src spec; exit 0",
+    "lint": "eslint --ignore-pattern '/doc/*' --ignore-pattern '/lib/*' '**/*.js' ; exit 0",
     "test": "NODE_PATH=${NODE_PATH:-\"$PWD/src\"} jasmine",
     "build": "babel --presets modern-node/4.0 --source-maps false --copy-files src -d lib",
     "prepublish": "npm run build"

--- a/spec/lib/DirectiveStackSpec.js
+++ b/spec/lib/DirectiveStackSpec.js
@@ -1,13 +1,13 @@
 const EventEmitter = require('events').EventEmitter;
-const ScopedDirectiveStack = require('ScopedDirectiveStack');
+const DirectiveStack = require('DirectiveStack');
 
-describe('ScopedDirectiveStack', () => {
+describe('DirectiveStack', () => {
   let mockParser, stack;
 
   beforeEach(() => {
     mockParser = new EventEmitter();
     spyOn(mockParser, 'on').and.callThrough();
-    stack = new ScopedDirectiveStack();
+    stack = new DirectiveStack();
     stack.listenTo(mockParser);
   });
 

--- a/spec/lib/LinterSpec.js
+++ b/spec/lib/LinterSpec.js
@@ -145,7 +145,7 @@ describe('Linter', () => {
           promise.then(({ errors, context: actualContext }) => {
             expect(errors).toEqual(errsWithNames);
             expect(actualContext.filename).toEqual(context.filename);
-            expect(actualContext.stack.constructor.name).toEqual('ScopedDirectiveStack');
+            expect(actualContext.stack.constructor.name).toEqual('DirectiveStack');
             done();
           });
         });

--- a/spec/lib/rules/component-name-matches-filenameSpec.js
+++ b/spec/lib/rules/component-name-matches-filenameSpec.js
@@ -17,7 +17,8 @@ describe('component-name-doesnt-match-filename', () => {
       const filename = `/foo/bar/${componentName}.html`;
 
       componentNameMatchesFilename({ filename }, mockParser, onError);
-      mockParser.emit('domModuleStartTag', componentName, { id: componentName }, false, {});
+      mockParser.emit('domModuleStartTag', componentName,
+        [ { name: 'id', value: componentName } ], false, {});
 
       expect(onError).not.toHaveBeenCalledTimes(1);
     });
@@ -31,7 +32,8 @@ describe('component-name-doesnt-match-filename', () => {
       const location = { line: 10, col: 20 };
 
       componentNameMatchesFilename({ filename }, mockParser, onError);
-      mockParser.emit('domModuleStartTag', componentName, { id: componentName }, false, location);
+      mockParser.emit('domModuleStartTag', componentName,
+        [ { name: 'id', value: componentName } ], false, location);
 
       expect(onError).toHaveBeenCalledTimes(1);
       expect(onError).toHaveBeenCalledWith({

--- a/spec/lib/rules/no-unused-importSpec.js
+++ b/spec/lib/rules/no-unused-importSpec.js
@@ -15,7 +15,35 @@ describe('no-unused-import', () => {
 
   describe('when all imported components are used', () => {
     beforeEach(() => {
-      mockParser.emit('customElementStartTag', componentName, {}, false, {});
+      mockParser.emit('customElementStartTag', componentName, [], false, {});
+      mockParser.emit('end');
+    });
+
+    it('does not call the onError callback', () => {
+      expect(onError).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when an imported component is used in a <style> tag\'s ' +
+           '`include` attribute', () => {
+    beforeEach(() => {
+      // <style include="...">
+      mockParser.emit('startTag', 'style',
+        [ { name: 'include', value: componentName } ], false, {});
+      mockParser.emit('end');
+    });
+
+    it('does not call the onError callback', () => {
+      expect(onError).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when an imported component is used in a built-in element\'s ' +
+           '`is` attribute', () => {
+    beforeEach(() => {
+      // <button is="...">
+      mockParser.emit('startTag', 'button',
+        [ { name: 'is', value: componentName } ], false, {});
       mockParser.emit('end');
     });
 

--- a/spec/lib/rules/one-componentSpec.js
+++ b/spec/lib/rules/one-componentSpec.js
@@ -13,7 +13,7 @@ describe('one-component', () => {
 
   describe('when one component is defined', () => {
     beforeEach(() => {
-      mockParser.emit('domModuleStartTag', 'foo', {}, false, {});
+      mockParser.emit('domModuleStartTag', 'foo', [], false, {});
     });
 
     it('does not call the onError callback', () => {
@@ -24,7 +24,7 @@ describe('one-component', () => {
       const location = { line: 6, col: 13 };
 
       beforeEach(() => {
-        mockParser.emit('domModuleStartTag', 'bar', {}, false, location);
+        mockParser.emit('domModuleStartTag', 'bar', [], false, location);
       });
 
       it('calls the onError callback with the expected arguments', () => {

--- a/spec/lib/rules/style-inside-templateSpec.js
+++ b/spec/lib/rules/style-inside-templateSpec.js
@@ -14,19 +14,19 @@ describe('style-inside-template', () => {
 
   describe('when <style> is inside <template>', () => {
     beforeEach(() => {
-      mockParser.emit('startTag', 'template', {}, false, {});
+      mockParser.emit('startTag', 'template', [], false, {});
     });
 
     it('does not call the onError callback', () => {
-      mockParser.emit('startTag', 'style', {}, false, {});
+      mockParser.emit('startTag', 'style', [], false, {});
       expect(onError).not.toHaveBeenCalled();
     });
   });
 
   describe('when <style> is before <template>', () => {
     it('calls the onError callback with the expected arguments', () => {
-      mockParser.emit('startTag', 'style', {}, false, location);
-      mockParser.emit('startTag', 'template', {}, false, {});
+      mockParser.emit('startTag', 'style', [], false, location);
+      mockParser.emit('startTag', 'template', [], false, {});
 
       expect(onError).toHaveBeenCalledWith({
         message: '<style> tag outside of <template>', location,
@@ -36,9 +36,9 @@ describe('style-inside-template', () => {
 
   describe('when <style> is after </template>', () => {
     it('calls the onError callback with the expected arguments', () => {
-      mockParser.emit('startTag', 'template', {}, false, {});
+      mockParser.emit('startTag', 'template', [], false, {});
       mockParser.emit('endTag', 'template');
-      mockParser.emit('startTag', 'style', {}, false, location);
+      mockParser.emit('startTag', 'style', [], false, location);
 
       expect(onError).toHaveBeenCalledWith({
         message: '<style> tag outside of <template>', location,
@@ -49,8 +49,8 @@ describe('style-inside-template', () => {
   describe('when <template> is self-closing', () => {
     it('calls the onError callback with the expected arguments', () => {
       const selfClosing = true;
-      mockParser.emit('startTag', 'template', {}, selfClosing, {});
-      mockParser.emit('startTag', 'style', {}, false, location);
+      mockParser.emit('startTag', 'template', [], selfClosing, {});
+      mockParser.emit('startTag', 'style', [], false, location);
 
       expect(onError).toHaveBeenCalledWith({
         message: '<style> tag outside of <template>', location,

--- a/spec/lib/util/getAttributeSpec.js
+++ b/spec/lib/util/getAttributeSpec.js
@@ -1,0 +1,28 @@
+const getAttribute = require('util/getAttribute');
+
+describe('getAttribute', () => {
+  describe('given an empty array', () => {
+    it('returns undefined', () => {
+      const attrs = [];
+      expect(getAttribute(attrs, 'foo')).toBe(undefined);
+    });
+  });
+
+  describe('given an array of objects', () => {
+    const attrs = [ { name: 'foo', value: 'a' }, { name: 'bar', value: 'b' } ];
+
+    describe('having an object with a `name` property equal to the ' +
+             'given name', () => {
+      it('returns the object\'s `value` property', () => {
+        expect(getAttribute(attrs, 'bar')).toEqual('b');
+      });
+    });
+
+    describe('not having an object with a `name` property equal to the ' +
+             'given name', () => {
+      it('returns undefined', () => {
+        expect(getAttribute(attrs, 'qux')).toBe(undefined);
+      });
+    });
+  });
+});

--- a/src/DirectiveStack.js
+++ b/src/DirectiveStack.js
@@ -1,16 +1,16 @@
 /**
  * @typedef {string[]} DirectiveArgs
- * @memberof ScopedDirectiveStack
+ * @memberof DirectiveStack
  */
 
 /**
- * @typedef {ScopedDirectiveStack.DirectiveArgs[]} DirectiveArgsStack
- * @memberof ScopedDirectiveStack
+ * @typedef {DirectiveStack.DirectiveArgs[]} DirectiveArgsStack
+ * @memberof DirectiveStack
  */
 
 /**
- * @typedef {Object.<string, ScopedDirectiveStack.DirectiveArgsStack>} DirectiveArgsStackObject
- * @memberof ScopedDirectiveStack
+ * @typedef {Object.<string, DirectiveStack.DirectiveArgsStack>} DirectiveArgsStackObject
+ * @memberof DirectiveStack
  */
 
 // Private methods
@@ -23,20 +23,20 @@ const initSnapshots = Symbol('initSnapshots');
 const snapshots = Symbol('snapshots');
 
 /**
- * @class ScopedDirectiveStack
+ * @class DirectiveStack
  * @extends {Array}
  * @classdesc
  * A subclass of Array for tracking linter directives.
  *
  * ### The stack
 
- * ScopedDirectiveStack acts like a stack. Each item in the stack is a
- * [DirectiveArgsStackObject]{@link ScopedDirectiveStack.DirectiveArgsStackObject}
+ * DirectiveStack acts like a stack. Each item in the stack is a
+ * [DirectiveArgsStackObject]{@link DirectiveStack.DirectiveArgsStackObject}
  * of the form:
  *
  * ```javascript
  * { 'directive-name': [
- *     [ 'arg1', 'arg2', ...  ],
+ *     [ 'arg1', 'arg2', ... ],
  *     // ...
  *   ],
  *   // ...
@@ -44,30 +44,29 @@ const snapshots = Symbol('snapshots');
  * ```
  *
  * In other words, each property's name is the name of a linter directive and
- * the corresponding value is an array of arrays of the arguments that have
- * been collected for that directive ([DirectiveArgsStack]{@link ScopedDirectiveStack.DirectiveArgsStack}).
+ * the corresponding value is an array of arrays of the arguments that have been
+ * collected for that directive ([DirectiveArgsStack]{@link DirectiveStack.DirectiveArgsStack}).
  *
- * ScopedDirectiveStack listens for events emitted by the {@link SAXParser}
- * given to its [listenTo]{@link ScopedDirectiveStack#listenTo} method for the
- * `linterDirective`, `enterScope`, and `leaveScope` events. It responds in the
- * following ways:
+ * DirectiveStack listens for events emitted by the {@link SAXParser} given to
+ * its [listenTo]{@link DirectiveStack#listenTo} method for the
+ * `linterDirective`, `enterScope`, and `leaveScope` events. It responds in the following ways:
  *
  *   * {@link SAXParser.event:linterDirective} - If the
- *     [DirectiveArgsStackObject]{@link ScopedDirectiveStack.DirectiveArgsStackObject}
+ *     [DirectiveArgsStackObject]{@link DirectiveStack.DirectiveArgsStackObject}
  *     on top of the stack does not have a property with the name of the
  *     directive given by the event, one is initialized with an empty array
- *     ([DirectiveArgsStack]{@link ScopedDirectiveStack.DirectiveArgsStack}).
- *     Then the [DirectiveArgs]{@link ScopedDirectiveStack.DirectiveArgs} given
- *     by the event are pushed onto that array.
+ *     ([DirectiveArgsStack]{@link DirectiveStack.DirectiveArgsStack}). Then the
+ *     [DirectiveArgs]{@link DirectiveStack.DirectiveArgs} given by the event
+ *     are pushed onto that array.
  *
- *     A snapshot is recorded (see "Snapshots").
+ *     A snapshot is recorded (see [Snapshots](#snapshots)).
  *
  *   * {@link SAXParser.event:enterScope} - A new, empty
- *     [DirectiveArgsStackObject]{@link ScopedDirectiveStack.DirectiveArgsStackObject}
+ *     [DirectiveArgsStackObject]{@link DirectiveStack.DirectiveArgsStackObject}
  *     is pushed onto the stack.
  *
- *   * {@link SAXParser.event:leaveScope} - The top object is popped from the stack
- *     and a snapshot is recorded (see "Snapshots").
+ *   * {@link SAXParser.event:leaveScope} - The top object is popped from the
+ *     stack and a snapshot is recorded (see [Snapshots](#snapshots)).
  *
  * ### Example
  *
@@ -91,7 +90,7 @@ const snapshots = Symbol('snapshots');
  * top|bottom {}
  * ```
  *
- * The empty [DirectiveArgsStackObject]{@link ScopedDirectiveStack.DirectiveArgsStackObject}
+ * The empty [DirectiveArgsStackObject]{@link DirectiveStack.DirectiveArgsStackObject}
  * represents the root scope. It's empty because no directives have been
  * encountered yet. After the parser parses line 1, the stack looks like this:
  *
@@ -128,11 +127,10 @@ const snapshots = Symbol('snapshots');
  * `sleepy` and once with the argument `sneezy`, and `directive-y` was
  * encountered once with the argument `doc`.
  *
- * ScopedDirectiveStack provides a convenience method
- * [getDirectiveArgs]{@link ScopedDirectiveStack#getDirectiveArgs} that will
- * traverse the stack and return an array of the arguments encountered with the
- * given directive name. By default it concatenates all of the
- * [DirectiveArgs]{@link ScopedDirectiveStack.DirectiveArgs} arrays into a
+ * DirectiveStack provides a convenience method [getDirectiveArgs]{@link DirectiveStack#getDirectiveArgs}
+ * that will traverse the stack and return an array of the arguments encountered
+ * with the given directive name. By default it concatenates all of the
+ * [DirectiveArgs]{@link DirectiveStack.DirectiveArgs} arrays into a
  * single array.
  *
  * ```javascript
@@ -159,15 +157,15 @@ const snapshots = Symbol('snapshots');
  * ### Snapshots
  *
  * Whenever a `linterDirective` or `leaveScope` event is received, the
- * ScopedDirectiveStack will record a "snapshot" of itself along with the
+ * DirectiveStack will record a "snapshot" of itself along with the
  * {@link SAXParser.LocationInfo} object given by those events. This allows us
  * to inspect the state of the stack corresponding to any location.
  *
- * **Note:** A snapshot is *not* recorded when an `enterScope`
- * event is received, because those events do not affect which directives are
+ * **Note:** A snapshot is *not* recorded when an `enterScope` event is
+ * received, because those events do not affect which directives are
  * "in effect."
  *
- * A snapshot can be retrieved using the [snapshotAtLocation]{@link ScopedDirectiveStack#snapshotAtLocation}
+ * A snapshot can be retrieved using the [snapshotAtLocation]{@link DirectiveStack#snapshotAtLocation}
  * method. For example, given the following markup:
  *
  * ```text
@@ -188,23 +186,23 @@ const snapshots = Symbol('snapshots');
  *
  * ```javascript
  * stack.snapshotAtLocation({ line: 5, col: 1 });
- * // => ScopedDirectiveStack [
+ * // => DirectiveStack [
  * //      {},
  * //      { 'directive-x': [ [ 'bashful', 'dopey' ] ] },
  * //      { 'directive-y': [ [ 'happy' ] ] }
  * //    ]
  *
  * stack.snapshotAtLocation({ line: 7, col: 1 });
- * // => ScopedDirectiveStack [
+ * // => DirectiveStack [
  * //      {},
  * //      { 'directive-x': [ [ 'bashful', 'dopey' ] ] }
  * //    ]
  *
  * stack.snapshotAtLocation({ line: 9, col: 1 });
- * // => ScopedDirectiveStack [ {} ]
+ * // => DirectiveStack [ {} ]
  * ```
  */
-class ScopedDirectiveStack extends Array {
+class DirectiveStack extends Array {
   /**
    * @param {Object} options
    * @param {boolean} [options.snapshot]
@@ -227,7 +225,7 @@ class ScopedDirectiveStack extends Array {
 
   /**
    * Returns the item on top of the stack without popping it
-   * @return {ScopedDirectiveStack.DirectiveArgsStackObject}
+   * @return {DirectiveStack.DirectiveArgsStackObject}
    */
   peek() {
     return this[this.length - 1];
@@ -252,11 +250,11 @@ class ScopedDirectiveStack extends Array {
   }
 
   /**
-   * Get the snapshot of the stack nearest to but not after the given
-   * location (see "Snapshots").
+   * Get the snapshot of the stack nearest to but not after the given location
+   * (see [Snapshots](#snapshots)).
    *
    * @param {LocationInfo} location
-   * @return {ScopedDirectiveStack}
+   * @return {DirectiveStack}
    */
   snapshotAtLocation({ line, col }) {
     const snaps = this[snapshots];
@@ -298,7 +296,7 @@ class ScopedDirectiveStack extends Array {
 
   /**
    * Returns a copy of itself
-   * @return {ScopedDirectiveStack}
+   * @return {DirectiveStack}
    */
   clone() {
     return this.constructor.from(this);
@@ -333,4 +331,4 @@ class ScopedDirectiveStack extends Array {
   }
 }
 
-module.exports = ScopedDirectiveStack;
+module.exports = DirectiveStack;

--- a/src/Linter.js
+++ b/src/Linter.js
@@ -6,7 +6,7 @@ const { isString } = require('util');
 
 const { enabledRules } = require('./util');
 const SAXParser = require('./SAXParser');
-const ScopedDirectiveStack = require('./ScopedDirectiveStack');
+const DirectiveStack = require('./DirectiveStack');
 
 /**
  * @typedef LinterOptions
@@ -18,7 +18,7 @@ const ScopedDirectiveStack = require('./ScopedDirectiveStack');
  * @typedef LintStreamContext
  * @type {Object}
  * @property {string} filename=
- * @property {ScopedDirectiveStack} stack
+ * @property {DirectiveStack} stack
  * @memberof Linter
  */
 
@@ -115,7 +115,7 @@ class Linter {
     const parser = new SAXParser({ locationInfo: true });
     const errors = [];
 
-    const stack = new ScopedDirectiveStack();
+    const stack = new DirectiveStack();
     stack.listenTo(parser);
 
     const onError = rule =>

--- a/src/SAXParser.js
+++ b/src/SAXParser.js
@@ -14,6 +14,7 @@
  */
 const parse5 = require('parse5');
 
+const getAttribute = require('./util/getAttribute');
 const isValidCustomElementName = require('./util/isValidCustomElementName');
 
 /**
@@ -109,11 +110,6 @@ const isValidCustomElementName = require('./util/isValidCustomElementName');
  * @description Emitted when the linter leaves a scope (i.e. an end tag).
  * @param {LocationInfo} location
  */
-
-function getAttribute(attrs, attrName) {
-  const attr = attrs.find(({ name }) => name === attrName);
-  return attr && attr.value;
-}
 
 const SPLIT_DIRECTIVE_ARGS_EXPR = /\s*(?:,\s*)+/;
 

--- a/src/rules/no-missing-import.js
+++ b/src/rules/no-missing-import.js
@@ -1,5 +1,7 @@
 // Rule: no-missing-imports
 const componentNameFromPath = require('../util/componentNameFromPath');
+const getAttribute = require('../util/getAttribute');
+const isValidCustomElementName = require('../util/isValidCustomElementName');
 
 /**
  * Checks if each custom element referenced in a template has a
@@ -15,18 +17,33 @@ const componentNameFromPath = require('../util/componentNameFromPath');
 module.exports = function noMissingImport(context, parser, onError) {
   const imports = {};
 
+  const check = (name, location) => imports[name] || onError({
+    message: `Custom element '${name}' used but not imported`,
+    location,
+  });
+
   parser.on('importTag', href => {
     const name = componentNameFromPath(href);
     imports[name] = true;
   });
 
-  parser.on('customElementStartTag', (name, attrs, selfClosing, location) => {
-    if (imports[name]) {
-      return;
+  parser.on('startTag', (name, attrs, selfClosing, location) => {
+    let componentName;
+
+    if (name === 'style') {
+      // <style include="...">
+      componentName = getAttribute(attrs, 'include');
+    } else if (!isValidCustomElementName(name)) {
+      // Extended built-in element, e.g. <button is="...">
+      componentName = getAttribute(attrs, 'is');
     }
-    onError({
-      message: `Custom element <${name}> used but not imported`,
-      location,
-    });
+
+    if (componentName) {
+      check(componentName, location);
+    }
+  });
+
+  parser.on('customElementStartTag', (name, attrs, selfClosing, location) => {
+    check(name, location);
   });
 };

--- a/src/rules/no-unused-import.js
+++ b/src/rules/no-unused-import.js
@@ -1,5 +1,7 @@
 // Rule: no-unused-import
 const componentNameFromPath = require('../util/componentNameFromPath');
+const getAttribute = require('../util/getAttribute');
+const isValidCustomElementName = require('../util/isValidCustomElementName');
 
 /**
  * Checks if all imported components are used.
@@ -23,6 +25,22 @@ module.exports = function noUnusedImport(context, parser, onError) {
        * @todo Is this the correct behavior?
        */
       imports.push([ name, location ]);
+    }
+  });
+
+  parser.on('startTag', (name, attrs) => {
+    let componentName;
+
+    if (name === 'style') {
+      // <style include="..."/>
+      componentName = getAttribute(attrs, 'include');
+    } else if (!isValidCustomElementName(name)) {
+      // Extended built-in element, e.g. <button is="...">
+      componentName = getAttribute(attrs, 'is');
+    }
+
+    if (componentName) {
+      usedImports[componentName] = true;
     }
   });
 

--- a/src/util/getAttribute.js
+++ b/src/util/getAttribute.js
@@ -1,0 +1,15 @@
+/**
+ * Given an `attributes` array of the form [ { name: string, value: string }, ... ],
+ * returns the `value` property of the first object with a `name`
+ * matching the given `attributeName`.
+ * @function getAttribute
+ * @param {Array.<{name: string, value: string}>} attributes
+ *   An array of attribute objects
+ * @param {string} attributeName
+ *   The name of the attribute to get the value of
+ * @return {string} - The attribute value
+ */
+module.exports = function getAttribute(attributes, attributeName) {
+  const attr = attributes.find(({ name }) => name === attributeName);
+  return attr && attr.value;
+};


### PR DESCRIPTION
- Fix: The no-missing-import and no-unused-import rules were missing cases where a component was used as the `include` attribute of a `<style>` element or the `is` attribute of a built-in element.
- Extract `getAttribute` function from SAXParser into utils.
- Fix some specs where element attributes passed to `mockParser.emit` were being passed as an object instead of an array.
- Rename ScopedDirectiveStack to DirectiveStack because long.