### PR TITLE
add icon-titles rule (WIP)

### DIFF
--- a/spec/lib/rules/icon-titlesSpec.js
+++ b/spec/lib/rules/icon-titlesSpec.js
@@ -1,0 +1,47 @@
+const { EventEmitter } = require('events');
+const iconTitles = require('rules/icon-titles');
+
+describe('icon-titles', () => {
+  let mockParser, onError;
+
+  beforeEach(() => {
+    mockParser = new EventEmitter();
+    onError = jasmine.createSpy('onError');
+
+    iconTitles({}, mockParser, onError);
+  });
+
+  describe('when icon tag has title attribute', () => {
+    beforeEach(() => {
+      mockParser.emit('startTag', 'jha-icon-chevron', [{name: "title", value: "foo"}], false, {});
+    });
+
+    it('does not call the onError callback', () => {
+      expect(onError).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when component is NOT an icon', () => {
+    beforeEach(() => {
+      mockParser.emit('startTag', 'jha-button', [], false, {});
+    });
+
+    it('does not call the onError callback', () => {
+      expect(onError).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when icon tag has no title attribute', () => {
+    const location = { line: 6, col: 13 };
+    beforeEach(() => {
+      mockParser.emit('startTag', 'jha-icon-chevron', [], false, location);
+    });
+
+    it('calls onError as expected', () => {
+      expect(onError).toHaveBeenCalledWith({
+        message: 'Icon has no title attribute: jha-icon-chevron',
+        location,
+      });
+    });
+  });
+});

--- a/src/rules/icon-titles.js
+++ b/src/rules/icon-titles.js
@@ -1,0 +1,27 @@
+// Rule: icon titles
+/**
+ * checks that every instance of jha-icon includes a title attribute
+ *
+ * @function icon-titles
+ * @memberof module:lib/rules
+ * @param {Linter.LintStreamContext} context
+ * @param {SAXParser} parser
+ * @param {OnErrorCallback} onError
+ * @return {void}
+ */
+module.exports = function iconTitles(context, parser, onError) {
+  const iconRegExp = new RegExp(/jha-icon-[\w-]+/);
+  parser.on('startTag', (name, attrs, selfClosing, location) => {
+    if (
+      !name.match(iconRegExp) ||
+      (name.match(iconRegExp) &&
+        attrs.filter(attr => attr.name === 'title').length)
+    ) {
+      return;
+    }
+    onError({
+      message: `Icon has no title attribute: ${name}`,
+      location
+    });
+  });
+};


### PR DESCRIPTION
## What it does
this PR adds a rule that checks to make sure any instance of jha-icon-* includes a title attribute.  Chad K mentioned that it would be a good idea to have it... and I thought it sounded fun to investigate.

The implementation is pretty simple.. it just looks for a tag named `jha-icon-*` (uses regex to check the wildcard) and makes sure the title attribute is present.

## Caveats
I added simple specs so I'm pretty sure it works, but I have NOT added any integration tests (yet).  I _did_ play with the integration tests and it appears that the new rule works.. but I was having a hard time adding to the integration tests without breaking existing tests.

I also have not added any special syntax for negating the rule (not EVERY icon needs a title) because I was not sure the best way to do that.  We can, of course, just use the existing disable command.

Also... I'm not 100% sure I actually know what I'm doing here, so if I've done something completely stupid let me know ;)

I should also mention that adding this rule will create a lot of linter errors in banno-online because there ARE some icons that do not have titles (_intentionally_)