### PR TITLE
adding an no-unused-import exception for polymer-element

### DIFF
--- a/spec/lib/rules/no-unused-importSpec.js
+++ b/spec/lib/rules/no-unused-importSpec.js
@@ -73,7 +73,7 @@ describe('no-unused-import', () => {
       mockParser.emit('end');
     });
 
-    it('does not call the onError callback despite, polymer-element not being used', () => {
+    it('does not call the onError callback despite polymer-element not being used', () => {
       expect(onError).not.toHaveBeenCalled();
     });
   })

--- a/spec/lib/rules/no-unused-importSpec.js
+++ b/spec/lib/rules/no-unused-importSpec.js
@@ -64,4 +64,17 @@ describe('no-unused-import', () => {
       });
     });
   });
+
+  describe('when polymer-element is imported', () => {
+    beforeEach(() => {
+      mockParser.emit('importTag', `/foo/bar/polymer-element.html`, location);
+      // only use the base test component
+      mockParser.emit('customElementStartTag', componentName, [], false, {});
+      mockParser.emit('end');
+    });
+
+    it('does not call the onError callback despite, polymer-element not being used', () => {
+      expect(onError).not.toHaveBeenCalled();
+    });
+  })
 });

--- a/spec/lib/rules/no-unused-importSpec.js
+++ b/spec/lib/rules/no-unused-importSpec.js
@@ -76,5 +76,5 @@ describe('no-unused-import', () => {
     it('does not call the onError callback despite polymer-element not being used', () => {
       expect(onError).not.toHaveBeenCalled();
     });
-  })
+  });
 });

--- a/src/rules/no-unused-import.js
+++ b/src/rules/no-unused-import.js
@@ -3,6 +3,8 @@ const componentNameFromPath = require('../util/componentNameFromPath');
 const getAttribute = require('../util/getAttribute');
 const isValidCustomElementName = require('../util/isValidCustomElementName');
 
+const exceptedTags = ['polymer-element'];
+
 /**
  * Checks if all imported components are used.
  *
@@ -19,7 +21,7 @@ module.exports = function noUnusedImport(context, parser, onError) {
 
   parser.on('importTag', (href, location) => {
     const name = componentNameFromPath(href);
-    if (name) {
+    if (name && !exceptedTags.includes(name)) {
       /**
        * Skip imports that aren't valid component names
        * @todo Is this the correct behavior?


### PR DESCRIPTION
Banno online will now use the polymer-element.html file and we need the linter not to throw the no-unused-imports error when its found in a component template.