### PR TITLE
no-hashtag-anchors rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,22 @@ Ensures that only one-way bindings (`[[val]]`) are used.
 <p>{{val}}</p>
 ```
 
+#### no-hashtag-anchors
+
+Ensures there are no anchor elements with `href="#"`.
+
+###### OK
+
+```html
+<a href="#anchor">Skip to anchor</a>
+```
+
+###### Error
+
+```html
+<a href="#">Skip to anchor</a>
+```
+
 #### no-missing-import
 
 Ensures that all components that are used have been imported.

--- a/lib/rules/no-hashtag-anchors.js
+++ b/lib/rules/no-hashtag-anchors.js
@@ -1,0 +1,50 @@
+'use strict';
+
+// Rule: no-hashtag-anchors
+
+const locationFromStringOffset = require('../util/locationFromStringOffset');
+const MATCH_HASHTAG_ANCHOR = /^#$/;
+
+/**
+ * Reports an error if any anchors contain href="#".
+ *
+ * @function no-hashtag-anchors
+ * @memberof module:lib/rules
+ * @param {Linter.LintStreamContext} context
+ * @param {SAXParser} parser
+ * @param {OnErrorCallback} onError
+ * @return {void}
+ */
+module.exports = function noHashtagAnchors(context, parser, onError) {
+  parser.on('startTag', (name, attrs, selfClosing, location) => {
+    if (name === 'a') {
+      for (const _ref of attrs) {
+        const name = _ref.name;
+        const value = _ref.value;
+
+        if (name !== 'href') {
+          continue;
+        }
+
+        const match = value.match(MATCH_HASHTAG_ANCHOR);
+
+        if (!match) {
+          continue;
+        }
+
+        const attrLocation = location.attrs[name];
+        const wholeAttribute = `${name}="${value}"`;
+
+        const startOffsetWithinAttr = name.length + 2 + match.index; // 2 for `="`
+        const endOffsetWithinAttr = startOffsetWithinAttr + match[0].length;
+        const bindingLocationWithinDocument =
+          locationFromStringOffset(wholeAttribute, startOffsetWithinAttr, endOffsetWithinAttr, attrLocation);
+
+        onError({
+          message: `Unexpected hashtag anchor`,
+          location: bindingLocationWithinDocument
+        });
+      }
+    }
+  });
+};

--- a/spec/lib/rules/no-hashtag-anchorsSpec.js
+++ b/spec/lib/rules/no-hashtag-anchorsSpec.js
@@ -1,0 +1,37 @@
+const { EventEmitter } = require('events');
+const noHashtagAnchors = require('rules/no-hashtag-anchors');
+
+describe('no-hashtag-anchors', () => {
+  let mockParser, onError;
+
+  beforeEach(() => {
+    mockParser = new EventEmitter();
+    onError = jasmine.createSpy('onError');
+    noHashtagAnchors({}, mockParser, onError);
+  });
+
+  describe('when a hashtag anchor is used', () => {
+    it('calls the onError callback with the expected arguments', () => {
+      /*
+        * col:║ 1   5  8    14
+        *     ║     │  │     │
+        *  L1 ╫     <a href="#">⏎  // line 1
+        *     ║ ⇡   ⇡  ⇡     ⇡⇡⇡⇡
+        * off:║ 0   4  7    13 15
+        *     ║               14 16
+        */
+      const attrLoc = { line: 1, col: 8, startOffset: 7, endOffset: 15 };
+      const startTagLoc = {
+        line: 1, col: 5, startOffset: 4, endOffset: 16,
+        attrs: { href: attrLoc },
+      };
+      const expectedBindingLoc = { line: 1, col: 14, startOffset: 13, endOffset: 14 };
+
+      mockParser.emit('startTag', 'a', [ { name: 'href', value: '#' } ], false, startTagLoc);
+      expect(onError).toHaveBeenCalledWith({
+        message: 'Unexpected hashtag anchor',
+        location: expectedBindingLoc,
+      });
+    });
+  });
+});

--- a/src/rules/no-hashtag-anchors.js
+++ b/src/rules/no-hashtag-anchors.js
@@ -1,0 +1,50 @@
+'use strict';
+
+// Rule: no-hashtag-anchors
+
+const locationFromStringOffset = require('../util/locationFromStringOffset');
+const MATCH_HASHTAG_ANCHOR = /^#$/;
+
+/**
+ * Reports an error if any anchors contain href="#".
+ *
+ * @function no-hashtag-anchors
+ * @memberof module:lib/rules
+ * @param {Linter.LintStreamContext} context
+ * @param {SAXParser} parser
+ * @param {OnErrorCallback} onError
+ * @return {void}
+ */
+module.exports = function noHashtagAnchors(context, parser, onError) {
+  parser.on('startTag', (name, attrs, selfClosing, location) => {
+    if (name === 'a') {
+      for (const _ref of attrs) {
+        const name = _ref.name;
+        const value = _ref.value;
+
+        if (name !== 'href') {
+          continue;
+        }
+
+        const match = value.match(MATCH_HASHTAG_ANCHOR);
+
+        if (!match) {
+          continue;
+        }
+
+        const attrLocation = location.attrs[name];
+        const wholeAttribute = `${name}="${value}"`;
+
+        const startOffsetWithinAttr = name.length + 2 + match.index; // 2 for `="`
+        const endOffsetWithinAttr = startOffsetWithinAttr + match[0].length;
+        const bindingLocationWithinDocument = locationFromStringOffset(
+          wholeAttribute, startOffsetWithinAttr, endOffsetWithinAttr, attrLocation);
+
+        onError({
+          message: `Unexpected hashtag anchor`,
+          location: bindingLocationWithinDocument
+        });
+      }
+    }
+  });
+};


### PR DESCRIPTION
## Summary
This is a branch that I've had sitting around collecting dust, so I figured I'd PR it. It adds a new rule, `no-hashtag-anchors` to warn about anchors with `href="#"`. I don't remember the exact impetus behind this, but I don't think those are something we want in apps.